### PR TITLE
Added prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Fast and memory efficient library for factorization machines (FM).
 - Runs on local machine and distributed clusters.
 - Scales to datasets with billions examples and features.
 
+### Prerequisites
+
+Install Google Test in order for difacto project to compile. (Intructions here [googletest.md](https://github.com/dmlc/difacto/tree/master/googletest.md))
+
 ### Quick Start
 
 The following commands clone and build difacto, then download a sample dataset,

--- a/googletest.md
+++ b/googletest.md
@@ -1,0 +1,26 @@
+#INSTALL google test in ubuntu / debian
+based on this stackoverflow answer: [http://stackoverflow.com/a/13513907](http://stackoverflow.com/a/13513907)
+
+##0. Install  cmake in ubuntu
+    apt-get install cmake
+
+##1. Get the googletest framework
+    cd /usr/local/src
+    wget https://github.com/google/googletest/archive/release-1.7.0.tar.gz
+
+##2. Unpack and build google test
+    tar xf release-1.7.0.tar.gz
+    cd googletest-release-1.7.0
+    cmake -DBUILD_SHARED_LIBS=ON .
+    make
+
+###3. "Install" the headers and libs on your system.
+This step might differ from distro to distro, so make sure you copy the headers and libs in the correct directory. I accomplished this by checking where Debians former gtest libs were located. But I'm sure there are better ways to do this. Note: make install is dangerous and not supported
+
+    cp -a include/gtest /usr/include
+    cp -a libgtest_main.so libgtest.so /usr/lib/
+
+##4. Update the cache of the linker
+... and check if the GNU Linker knows the libs
+
+    ldconfig -v | grep gtest


### PR DESCRIPTION
You need google test installed in order to compile difacto.

Added a tiny guide to accomplish this task in ubuntu/debian